### PR TITLE
Fixed: [R6-77] Corrige estados de carregamento de loading das imagens

### DIFF
--- a/lib/presentation/bloc/movie_event/series_event.dart
+++ b/lib/presentation/bloc/movie_event/series_event.dart
@@ -1,0 +1,13 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+
+@immutable
+abstract class SeriesEvent extends Equatable {
+  const SeriesEvent();
+  @override
+  List<Object> get props => [];
+}
+
+class LoadingSeriesSuccessEvent extends SeriesEvent {
+}
+class NetworkSeriesErrorEvent extends Error {}

--- a/lib/presentation/bloc/movie_state/movie_state.dart
+++ b/lib/presentation/bloc/movie_state/movie_state.dart
@@ -15,10 +15,10 @@ class InitialState extends MovieState {}
 class LoadingState extends MovieState {}
 
 class LoadedSuccessState extends MovieState {
-  final List<SeriesModels>? series;
+
   final List<MoviesModels>? movies;
 
-  const LoadedSuccessState({this.movies, this.series});
+  const LoadedSuccessState({this.movies});
 }
 
 class ErrorState extends MovieState {

--- a/lib/presentation/bloc/movie_state/series_state.dart
+++ b/lib/presentation/bloc/movie_state/series_state.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:r6_moovie_app/data/models/series_model.dart';
+import '../../../data/models/movies_model.dart';
+
+@immutable
+abstract class SeriesState extends Equatable {
+  const SeriesState();
+  @override
+  List<Object> get props => [];
+}
+
+class InitialSeriesState extends SeriesState {}
+
+class LoadingSeriesState extends SeriesState {}
+
+class LoadedSeriesSuccessState extends SeriesState {
+  final List<SeriesModels>? series;
+
+  const LoadedSeriesSuccessState(this.series);
+
+}
+
+class ErrorSeriesState extends SeriesState {
+  final String? error;
+  const ErrorSeriesState({required this.error});
+}

--- a/lib/presentation/bloc/series_bloc/series_bloc.dart
+++ b/lib/presentation/bloc/series_bloc/series_bloc.dart
@@ -1,24 +1,26 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:r6_moovie_app/data/repository/series_repository_impl.dart';
+import 'package:r6_moovie_app/presentation/bloc/movie_event/series_event.dart';
+import 'package:r6_moovie_app/presentation/bloc/movie_state/series_state.dart';
 
 import '../../../data/models/series_model.dart';
 import '../movie_event/movie_event.dart';
 import '../movie_state/movie_state.dart';
 
-class SerieBloc extends Bloc<MovieEvent, MovieState> {
-  SerieBloc() : super(InitialState()) {
+class SeriesBloc extends Bloc<SeriesEvent, SeriesState> {
+  SeriesBloc() : super(InitialSeriesState()) {
     final SeriesRepositoryImpl repository = SeriesRepositoryImpl();
 
-    on<LoadingSuccessEvent>((event, emit) async {
+    on<LoadingSeriesSuccessEvent>((event, emit) async {
       try {
-        emit(LoadingState());
-        print('<L> loading');
+        emit(LoadingSeriesState());
+        print('<L> loading seies');
         final List<SeriesModels> series = await repository.getPopularSeries();
         print("SERIES $series");
-        emit(LoadedSuccessState(series: series));
-        print('<L> success');
-      } on NetworkErrorEvent {
-        emit(const ErrorState(
+        emit(LoadedSeriesSuccessState(series));
+        print('<L> success seiries');
+      } on NetworkSeriesErrorEvent{
+        emit(const ErrorSeriesState(
             error: "Failure to get Series. Is your device online?"));
       }
     });

--- a/lib/presentation/components/banner_list.dart
+++ b/lib/presentation/components/banner_list.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:r6_moovie_app/data/models/movies_model.dart';
 import 'package:r6_moovie_app/data/models/series_model.dart';
@@ -53,11 +54,13 @@ class BannerList extends StatelessWidget {
                       children: [
                         ClipRRect(
                           borderRadius: BorderRadius.circular(10.0),
-                          child: Image.network(
+                          child: CachedNetworkImage(imageUrl:
                             "https://image.tmdb.org/t/p/w500${banner.backdropPath}",
                             fit: BoxFit.cover,
                             height: double.infinity,
                             width: double.infinity,
+                            placeholder: (context, url) => const CircularProgressIndicator(),
+                            errorWidget: (context, url, error) => Icon(Icons.error),
                           ),
                         ),
                         Positioned(

--- a/lib/presentation/components/media_list.dart
+++ b/lib/presentation/components/media_list.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:r6_moovie_app/data/models/movies_model.dart';
 import 'package:r6_moovie_app/data/models/series_model.dart';
@@ -68,11 +69,13 @@ class MediaList extends StatelessWidget {
                       children: [
                         ClipRRect(
                           borderRadius: BorderRadius.circular(10.0),
-                          child: Image.network(
+                          child: CachedNetworkImage(imageUrl:
                             "https://image.tmdb.org/t/p/w500${media.backdropPath}",
                             fit: BoxFit.cover,
                             height: double.infinity,
                             width: double.infinity,
+                            placeholder: (context, url) => const CircularProgressIndicator(),
+                            errorWidget: (context, url, error) => Icon(Icons.error),
                           ),
                         ),
                         Positioned(

--- a/lib/presentation/screens/main_screen.dart
+++ b/lib/presentation/screens/main_screen.dart
@@ -6,22 +6,27 @@ import 'package:r6_moovie_app/presentation/bloc/movie_state/movie_state.dart';
 import 'package:r6_moovie_app/presentation/bloc/series_bloc/series_bloc.dart';
 import 'package:r6_moovie_app/presentation/components/banner_list.dart';
 import 'package:r6_moovie_app/presentation/components/media_list.dart';
+import '../bloc/movie_event/series_event.dart';
+import '../bloc/movie_state/series_state.dart';
 
 class MainScreen extends StatefulWidget {
-  const MainScreen({Key? key}) : super(key: key);
+  const MainScreen({super.key});
 
   @override
   State<MainScreen> createState() => _MainScreenState();
+
 }
 
 class _MainScreenState extends State<MainScreen> {
   late final MovieBloc _movieBloc = MovieBloc();
-  late final SerieBloc _serieBloc = SerieBloc();
+  late final SeriesBloc _seriesBloc = SeriesBloc();
 
   @override
   void initState() {
+    MovieBloc();
+    SeriesBloc();
     _movieBloc.add(LoadingSuccessEvent());
-    _serieBloc.add(LoadingSuccessEvent());
+    _seriesBloc.add(LoadingSeriesSuccessEvent());
     super.initState();
   }
 
@@ -33,11 +38,14 @@ class _MainScreenState extends State<MainScreen> {
           BlocBuilder<MovieBloc, MovieState>(
             bloc: _movieBloc,
             builder: (context, movieState) {
-              return BlocBuilder<SerieBloc, MovieState>(
-                bloc: _serieBloc,
+              return BlocBuilder<SeriesBloc, SeriesState>(
+                bloc: _seriesBloc,
                 builder: (context, serieState) {
-                  if (movieState is LoadedSuccessState &&
-                      serieState is LoadedSuccessState) {
+                  if (movieState is LoadingState || serieState is LoadingSeriesState) {
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  } else if (movieState is LoadedSuccessState && serieState is LoadedSeriesSuccessState) {
                     return Column(
                       children: [
                         BannerList(
@@ -47,12 +55,12 @@ class _MainScreenState extends State<MainScreen> {
                         const Padding(padding: EdgeInsets.all(6.0)),
                         MediaList(
                           title: "Recomendados",
-                          mediaList: movieState.movies, movies: [], series: [],
+                          mediaList: movieState.movies ?? [], movies: [], series: [],
                         ),
                         const Padding(padding: EdgeInsets.all(6.0)),
                         MediaList(
                           title: "Series",
-                          mediaList: serieState.series, movies: [], series: [],
+                          mediaList: serieState.series ?? [], movies: [], series: [],
                         ),
                       ],
                     );
@@ -67,4 +75,5 @@ class _MainScreenState extends State<MainScreen> {
       ),
     );
   }
+
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "28ea9690a8207179c319965c13cd8df184d5ee721ae2ce60f398ced1219cea1f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "9e90e78ae72caa874a323d78fa6301b3fb8fa7ea76a8f96dc5b5bf79f283bf2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "205d6a9f1862de34b93184f22b9d2d94586b2f05c581d546695e3d8f6a805cd7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   characters:
     dependency: transitive
     description:
@@ -113,6 +137,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -126,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.5"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "395d6b7831f21f3b989ebedbb785545932adb9afe2622c1ffacf7f4b53a7e544"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -160,6 +216,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.4"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   image:
     dependency: transitive
     description:
@@ -232,6 +304,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "45b40f99622f11901238e18d48f5f12ea36426d8eced9f4cbf58479c7aa2430d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -240,6 +320,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -248,6 +376,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   provider:
     dependency: transitive
     description:
@@ -256,6 +400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -269,6 +421,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -293,6 +469,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -325,6 +509,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -341,6 +533,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:
@@ -359,4 +575,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.1 <4.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.16.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_bloc: ^8.1.5
   equatable: ^2.0.5
   flutter_native_splash: ^2.3.9
+  cached_network_image: ^3.2.0
   
 
 flutter_native_splash:


### PR DESCRIPTION
### Descrição
Este PR corrige os estados de carregamento de imagens. Na classe MainScreen estva sendo utilizado BlocBuilder duas vezes, mas com blocos diferentes. E estava sendo utilizado o tipo de estado MovieState para ambas as construções do BlocBuilder. Foi adicionado um estado para cada Bloc. Adicionado um  pacote de carregamento de imagem como cached_network_image que fornece um widget CachedNetworkImage na qual  oferece suporte ao cache de imagens e exibe um indicador de progresso automaticamente enquanto a imagem está sendo baixada da web.

### Screenshort
[Screen_recording_20240513_081316.webm](https://github.com/desenvolve06/r6_moovie_app/assets/63366380/dbf46580-6c63-46b6-ab3c-5d0621006f22)

### Task
[R¨-77](https://trello.com/c/1O3sCDuJ/77-r6-77-corrigir-state-e-loading)